### PR TITLE
Add Epoxy to prerequisites in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ This package uses ```catkin build```. Tested on Ubuntu 20.04.
 ```
 sudo apt install libeigen3-dev
 ```
+### Epoxy
+```
+sudo apt-get install libepoxy-dev
+```
 ### Pangolin
 ```
 cd ~


### PR DESCRIPTION
While following the installation instructions, I ran into a snag. It seems that epoxy was not installed on my system. 

To clear the road for those that follow me I figured it might make sense to add Epoxy as a dependency in the README.

This might be related to #43 